### PR TITLE
add minor windows-specific fixes

### DIFF
--- a/src/ofxUbo.h
+++ b/src/ofxUbo.h
@@ -73,10 +73,10 @@ template <class T>
 ofxUbo<T>::ofxUbo(const ofxUboLayout &layout){
     bindingPoint = ofxUboSingeltons::findFirstAvaliableBindingSpot();
     bufferLayout = layout;
-    char buffer[layout.size];
+    vector<char> buffer(layout.size);
     glGenBuffers(1,&uboId);
     glBindBuffer(GL_UNIFORM_BUFFER,uboId);
-    glBufferData(GL_UNIFORM_BUFFER,layout.size,buffer,GL_DYNAMIC_DRAW);
+    glBufferData(GL_UNIFORM_BUFFER,layout.size,buffer.data(),GL_DYNAMIC_DRAW);
     glBindBufferBase(GL_UNIFORM_BUFFER,bindingPoint,uboId);
 }
 //--------------------------------------------------------------
@@ -91,8 +91,7 @@ template <class T>
 void ofxUbo<T>::loadData(const T &newData){
     char* dataPtr = (char*)&newData;
     // start with a zero buffer equal to the size of the layout
-    char buffer[bufferLayout.size];
-    memset(buffer, '0', bufferLayout.size);
+    vector<char> buffer(bufferLayout.size,'0');
     
     int dataOffest = 0;
     // loop through each unifom of bufferLayout, and add them to buffer
@@ -106,7 +105,7 @@ void ofxUbo<T>::loadData(const T &newData){
                 int rowOffset = matrixOffset;
                 // This loop uploads one matrix,one row at a time
                 for (int k = 0; k < ofxUboSingeltons::matrixRowCount[uniform.type]; k++) {
-                    memcpy(buffer + rowOffset, dataPtr + dataOffest, ofxUboSingeltons::matrixRowSize[uniform.type]);
+                    memcpy(buffer.data() + rowOffset, dataPtr + dataOffest, ofxUboSingeltons::matrixRowSize[uniform.type]);
                     dataOffest+=ofxUboSingeltons::matrixRowSize[uniform.type];
                     rowOffset+=uniform.matrixStride;
                 }
@@ -115,7 +114,7 @@ void ofxUbo<T>::loadData(const T &newData){
         }else if (uniform.arrayStride == 0 && uniform.matrixStride > 0 ){ // is it a matrix
             int rowOffset = uniform.offest;
             for (int k = 0; k < ofxUboSingeltons::matrixRowCount[uniform.type]; k++) {
-                memcpy(buffer + rowOffset, dataPtr + dataOffest, ofxUboSingeltons::matrixRowSize[uniform.type]);
+                memcpy(buffer.data() + rowOffset, dataPtr + dataOffest, ofxUboSingeltons::matrixRowSize[uniform.type]);
                 dataOffest+=ofxUboSingeltons::matrixRowSize[uniform.type];
                 rowOffset+=uniform.matrixStride;
             }
@@ -123,31 +122,25 @@ void ofxUbo<T>::loadData(const T &newData){
             int offset = uniform.offest;
             int arrayCount = uniform.size/uniform.arrayStride;
             for (int j = 0; j < arrayCount; j++) {
-                memcpy(buffer+offset, dataPtr + dataOffest, ofxUboSingeltons::spGLSLTypeSize[uniform.type]);
+                memcpy(buffer.data() + offset, dataPtr + dataOffest, ofxUboSingeltons::spGLSLTypeSize[uniform.type]);
                 dataOffest+=ofxUboSingeltons::spGLSLTypeSize[uniform.type];
                 offset+=uniform.arrayStride;
             }
         }else if (uniform.arrayStride == 0 && uniform.matrixStride == 0){// is it a regular type
             int offset = uniform.offest;
-            memcpy(buffer+offset, dataPtr + dataOffest, ofxUboSingeltons::spGLSLTypeSize[uniform.type]);
+            memcpy(buffer.data() + offset, dataPtr + dataOffest, ofxUboSingeltons::spGLSLTypeSize[uniform.type]);
             dataOffest+= ofxUboSingeltons::spGLSLTypeSize[uniform.type];
         }
     }
     glBindBuffer(GL_UNIFORM_BUFFER,uboId);
-    glBufferSubData(GL_UNIFORM_BUFFER,0,bufferLayout.size,buffer);
+    glBufferSubData(GL_UNIFORM_BUFFER,0,bufferLayout.size,buffer.data());
 }
 //--------------------------------------------------------------
 
 template <class T>
 void ofxUbo<T>::loadDataManually(const T &newData){
-    char* dataPtr = (char*)&newData;
-    // start with a zero buffer equal to the size of the layout
-    char buffer[bufferLayout.size];
-    memset(buffer, '0', bufferLayout.size);
-    //copy data into buffer
-    memcpy(buffer, dataPtr, sizeof(T));
     glBindBuffer(GL_UNIFORM_BUFFER,uboId);
-    glBufferSubData(GL_UNIFORM_BUFFER,0,bufferLayout.size,buffer);
+    glBufferSubData(GL_UNIFORM_BUFFER,0,bufferLayout.size,(char*)(&newData));
 }
 
 //--------------------------------------------------------------


### PR DESCRIPTION
hey @ahbee, 

First of all: This is great, and the example i got to run on windows after a bit of fiddling is beautiful!

i'm adding a couple of minor, windows specific fixes. These are mainly related to the vs2012 c++ compiler not allowing you to allocate c-style arrays of dynamic size. (ERR C2466). 

Using c++ vectors gives you the additional security that c++ takes care of cleaning up these memory object as soon as they fall out of scope, and so that might be useful for other implementations, too.
